### PR TITLE
feat: handle add meal errors

### DIFF
--- a/source/components/AddMealPage.test.tsx
+++ b/source/components/AddMealPage.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import test from 'ava';
+import {render} from 'ink-testing-library';
+
+// 模擬 addMealOption 拋出錯誤並顯示訊息
+// 需求：顯示錯誤訊息且不返回首頁
+
+test('show error message when addMealOption throws', async t => {
+	const {default: AddMealPage} = await t.mock('./AddMealPage.tsx', {
+		'../app.js': {default: () => null},
+	});
+
+	const {stdin, lastFrame} = render(
+		<AddMealPage
+			addMeal={() => {
+				throw new Error('DB error');
+			}}
+		/>,
+	);
+
+	// 模擬回答四個問題
+	for (let i = 0; i < 4; i++) {
+		stdin.write('\r');
+	}
+
+	// 等待 React 更新
+	await new Promise(resolve => setTimeout(resolve, 0));
+
+	t.true(lastFrame()?.includes('DB error'));
+});

--- a/source/components/AddMealPage.tsx
+++ b/source/components/AddMealPage.tsx
@@ -1,15 +1,15 @@
-import React, { useEffect, useState } from "react";
-import { Box, Text, useInput } from "ink";
-import { addMealOption } from "../db.js";
-import App from "../app.js";
-import TextInput from "./TextInput.js";
+import React, {useEffect, useState} from 'react';
+import {Box, Text, useInput} from 'ink';
+import App from '../app.js';
+import TextInput from './TextInput.js';
+import Notification from './Notification.js';
 
 // 定義要詢問用戶的問題列表
 const questions = [
-  "❤️ 新增收藏品項：",
-  "⭐️ 喜愛程度(1~5)：",
-  "📌 Tags(咖哩、麵包、素食...)：",
-  "📝 額外說明：",
+	'❤️ 新增收藏品項：',
+	'⭐️ 喜愛程度(1~5)：',
+	'📌 Tags(咖哩、麵包、素食...)：',
+	'📝 額外說明：',
 ];
 
 /**
@@ -17,160 +17,173 @@ const questions = [
  *
  * 逐步詢問用戶問題，收集餐點資訊。
  */
-const AddMealPage = () => {
-  // 用戶當前輸入的內容
-  const [inputStatement, setInputStatetment] = useState("");
 
-  // 儲存用戶對每個問題的回答
-  const [logs, setLogs] = useState<string[]>([]);
+type AddMeal = (option: {
+	name: string;
+	weight: number;
+	tags?: string;
+	description?: string;
+	metadata?: string;
+}) => unknown;
 
-  // 當前進行到第幾個問題的索引 (從 0 開始)
-  const [step, setStep] = useState(0);
+const AddMealPage = ({addMeal}: {addMeal: AddMeal}) => {
+	// 用戶當前輸入的內容
+	const [inputStatement, setInputStatetment] = useState('');
 
-  // 判斷是否所有問題都已回答完畢
-  const questionDone = step === questions.length;
+	// 儲存用戶對每個問題的回答
+	const [logs, setLogs] = useState<string[]>([]);
 
-  // 判斷是否已儲存到 DB
-  const [isSaved, setIsSaved] = useState(false);
+	// 當前進行到第幾個問題的索引 (從 0 開始)
+	const [step, setStep] = useState(0);
 
-  useInput((_, key) => {
-    if (key.return) {
-      setStep((prev) => {
-        if (prev >= questions.length) {
-          return prev;
-        }
-        return prev + 1;
-      });
+	// 判斷是否所有問題都已回答完畢
+	const questionDone = step === questions.length;
 
-      // write into logs and reset input.
-      setLogs((prev) => {
-        // 問題已回答完畢只需要顯示已有的回答
-        if (questionDone) {
-          return prev;
-        }
-        return [...prev, inputStatement];
-      });
-      setInputStatetment("");
-      return;
-    }
-  });
+	// 判斷是否已儲存到 DB
+	const [isSaved, setIsSaved] = useState(false);
+	// 儲存錯誤訊息，顯示於 UI
+	const [errorText, setErrorText] = useState<string>('');
 
-  // 問卷內容寫入 DB
-  useEffect(() => {
-    if (!questionDone) {
-      return;
-    }
+	useInput((_, key) => {
+		if (key.return) {
+			setStep(prev => {
+				if (prev >= questions.length) {
+					return prev;
+				}
+				return prev + 1;
+			});
 
-    let timer: NodeJS.Timeout | undefined = undefined;
-    try {
-      addMealOption({
-        name: logs[0] ?? "",
-        weight: Number(logs[1]),
-        tags: logs[2],
-        description: logs[3],
-        metadata: "", // 之後會有其他頁面功能寫入
-      });
-      // 故意停個幾秒讓用戶看自己輸入的列表
-      timer = setTimeout(() => {
-        // You don't need to do anything.
-        setIsSaved(true);
-      }, 2000);
-    } catch (error) {
-      // TODO: Handle errors
-    }
+			// write into logs and reset input.
+			setLogs(prev => {
+				// 問題已回答完畢只需要顯示已有的回答
+				if (questionDone) {
+					return prev;
+				}
+				return [...prev, inputStatement];
+			});
+			setInputStatetment('');
+			return;
+		}
+	});
 
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [questionDone]);
+	// 問卷內容寫入 DB
+	useEffect(() => {
+		if (!questionDone) {
+			return;
+		}
 
-  // 時間到自動切換到首頁
-  const [goHome, setGoHome] = useState(false);
+		let timer: NodeJS.Timeout | undefined = undefined;
+		try {
+			addMeal({
+				name: logs[0] ?? '',
+				weight: Number(logs[1]),
+				tags: logs[2],
+				description: logs[3],
+				metadata: '', // 之後會有其他頁面功能寫入
+			});
+			// 故意停個幾秒讓用戶看自己輸入的列表
+			timer = setTimeout(() => {
+				// You don't need to do anything.
+				setIsSaved(true);
+			}, 2000);
+		} catch (error) {
+			// 發生錯誤時保持在頁面並顯示訊息
+			setIsSaved(false);
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			setErrorText(message);
+		}
 
-  // 最後在顯示一秒儲存成功訊息 回到首頁
-  useEffect(() => {
-    if (!isSaved) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      setGoHome(true);
-    }, 1000);
+		return () => {
+			clearTimeout(timer);
+		};
+	}, [questionDone]);
 
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [isSaved]);
+	// 時間到自動切換到首頁
+	const [goHome, setGoHome] = useState(false);
 
-  /**
-   * Update input statement
-   */
-  const handleOnChange = (value: string) => {
-    setInputStatetment((prev) => prev + value);
-  };
+	// 最後在顯示一秒儲存成功訊息 回到首頁
+	useEffect(() => {
+		if (!isSaved) {
+			return;
+		}
+		const timer = setTimeout(() => {
+			setGoHome(true);
+		}, 1000);
 
-  /**
-   * Update input statement when delete
-   */
-  const handleOnDelete = (value: string) => {
-    setInputStatetment(value);
-  };
+		return () => {
+			clearTimeout(timer);
+		};
+	}, [isSaved]);
 
-  if (goHome) {
-    return <App />;
-  }
+	/**
+	 * Update input statement
+	 */
+	const handleOnChange = (value: string) => {
+		setInputStatetment(prev => prev + value);
+	};
 
-  if (isSaved) {
-    return (
-      <Box
-        flexDirection="column"
-        borderColor="yellow"
-        borderStyle={"round"}
-      >
-        <Text>已儲存</Text>
-      </Box>
-    );
-  }
+	/**
+	 * Update input statement when delete
+	 */
+	const handleOnDelete = (value: string) => {
+		setInputStatetment(value);
+	};
 
-  return (
-    <Box flexDirection="column">
-      <Box
-        flexDirection="column"
-        margin={1}
-        borderColor="yellow"
-        borderStyle={"round"}
-      >
-        <Text
-          color={"cyan"}
-          dimColor={true}
-        >
-          {questionDone ? "" : questions[step] ?? " "}
-        </Text>
-        {questionDone && logs.length > 0 && (
-          logs.map((item: string, index: number) => (
-            <Text key={`${index}-${item}`}>
-              {`${questions[index]}: ${item}`}
-            </Text>
-          ))
-        )}
-      </Box>
-      {!questionDone && (
-        <Box
-          flexDirection="column"
-          margin={1}
-          borderColor="green"
-          borderStyle={"round"}
-        >
-          {/* <Text color="cyan">▶ {inputStatement || " "}</Text> */}
-          <TextInput
-            value={inputStatement}
-            onChange={handleOnChange}
-            onDelete={handleOnDelete}
-          >
-          </TextInput>
-        </Box>
-      )}
-    </Box>
-  );
+	if (goHome) {
+		return <App />;
+	}
+
+	if (isSaved) {
+		return (
+			<Box flexDirection="column" borderColor="yellow" borderStyle={'round'}>
+				<Text>已儲存</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Box
+				flexDirection="column"
+				margin={1}
+				borderColor="yellow"
+				borderStyle={'round'}
+			>
+				<Text color={'cyan'} dimColor={true}>
+					{questionDone ? '' : questions[step] ?? ' '}
+				</Text>
+				{questionDone &&
+					logs.length > 0 &&
+					logs.map((item: string, index: number) => (
+						<Text key={`${index}-${item}`}>
+							{`${questions[index]}: ${item}`}
+						</Text>
+					))}
+			</Box>
+			{!questionDone && (
+				<Box
+					flexDirection="column"
+					margin={1}
+					borderColor="green"
+					borderStyle={'round'}
+				>
+					{/* <Text color="cyan">▶ {inputStatement || " "}</Text> */}
+					<TextInput
+						value={inputStatement}
+						onChange={handleOnChange}
+						onDelete={handleOnDelete}
+					></TextInput>
+				</Box>
+			)}
+			{errorText && (
+				<Notification
+					message={errorText}
+					duration={3000}
+					onDone={() => setErrorText('')}
+				/>
+			)}
+		</Box>
+	);
 };
 
 export default AddMealPage;

--- a/source/components/MealOptionsManager.tsx
+++ b/source/components/MealOptionsManager.tsx
@@ -1,15 +1,16 @@
-import React, { useCallback, useState } from "react";
-import { Text, useInput } from "ink";
-import App from "../app.js";
-import SelectInput from "./SelectInput.js";
-import Notification from "./Notification.js";
-import AddMealPage from "./AddMealPage.js";
+import React, {useCallback, useState} from 'react';
+import {Text, useInput} from 'ink';
+import App from '../app.js';
+import SelectInput from './SelectInput.js';
+import Notification from './Notification.js';
+import AddMealPage from './AddMealPage.js';
+import {addMealOption} from '../db.js';
 
-const mealOptions: { label: string; value: string }[] = [
-  { label: "新增餐點", value: "add" },
-  // { label: "編輯餐點", value: "edit" },
-  // { label: "刪除餐點", value: "delete" },
-  // { label: "返回", value: "escape" },
+const mealOptions: {label: string; value: string}[] = [
+	{label: '新增餐點', value: 'add'},
+	// { label: "編輯餐點", value: "edit" },
+	// { label: "刪除餐點", value: "delete" },
+	// { label: "返回", value: "escape" },
 ];
 
 /**
@@ -18,71 +19,66 @@ const mealOptions: { label: string; value: string }[] = [
  * 讓用戶用可以自行新增編輯餐點 DB 內容
  */
 const MealOptionsManager = () => {
-  // 用戶選擇
-  const [userSelected, setUserSelected] = useState<string>("");
+	// 用戶選擇
+	const [userSelected, setUserSelected] = useState<string>('');
 
-  /**
-   * 依照 user 選擇顯示功能畫面
-   */
-  const handleOnSelect = useCallback(
-    (item: { label: string; value: string }) => {
-      setUserSelected(item.value);
-    },
-    [],
-  );
+	/**
+	 * 依照 user 選擇顯示功能畫面
+	 */
+	const handleOnSelect = useCallback((item: {label: string; value: string}) => {
+		setUserSelected(item.value);
+	}, []);
 
-  const [inputActive, setInputActive] = useState(true);
+	const [inputActive, setInputActive] = useState(true);
 
-  useInput((input, key) => {
-    if (key.escape) {
-      setUserSelected("escape");
-      return;
-    }
+	useInput(
+		(input, key) => {
+			if (key.escape) {
+				setUserSelected('escape');
+				return;
+			}
 
-    if (input == "q") {
-      setUserSelected("q");
-      return;
-    }
+			if (input == 'q') {
+				setUserSelected('q');
+				return;
+			}
 
-    setInputActive(false);
-  }, {
-    isActive: inputActive,
-  });
+			setInputActive(false);
+		},
+		{
+			isActive: inputActive,
+		},
+	);
 
-  /**
-   * message 結束時間到就返回選項畫面
-   */
-  const handleOnDone = useCallback(() => {
-    setUserSelected("");
-  }, []);
+	/**
+	 * message 結束時間到就返回選項畫面
+	 */
+	const handleOnDone = useCallback(() => {
+		setUserSelected('');
+	}, []);
 
-  // 路線選擇
-  switch (userSelected) {
-    case "add":
-      return <AddMealPage />;
-    case "edit":
-      return <Text color="yellowBright">Still working on it</Text>; // return <div />;
-    case "delete":
-      return <Text color="yellowBright">Still working on it</Text>; // return <div />;
-    case "escape":
-      return <App />;
+	// 路線選擇
+	switch (userSelected) {
+		case 'add':
+			return <AddMealPage addMeal={addMealOption} />;
+		case 'edit':
+			return <Text color="yellowBright">Still working on it</Text>; // return <div />;
+		case 'delete':
+			return <Text color="yellowBright">Still working on it</Text>; // return <div />;
+		case 'escape':
+			return <App />;
 
-    case "q":
-      return (
-        <Notification
-          message="Use [Ctrl + c] to exit."
-          duration={1000}
-          onDone={handleOnDone}
-        />
-      );
-  }
+		case 'q':
+			return (
+				<Notification
+					message="Use [Ctrl + c] to exit."
+					duration={1000}
+					onDone={handleOnDone}
+				/>
+			);
+	}
 
-  return (
-    <SelectInput
-      optionItems={mealOptions}
-      onSelect={handleOnSelect}
-    />
-  );
+	return <SelectInput optionItems={mealOptions} onSelect={handleOnSelect} />;
 };
 
 export default MealOptionsManager;


### PR DESCRIPTION
## Summary
- prevent auto redirect when saving meal fails
- inject addMeal function and show errors via Notification
- cover add meal error flow with unit test

## Testing
- `npx prettier -c source/components/AddMealPage.tsx source/components/MealOptionsManager.tsx source/components/AddMealPage.test.tsx`
- `npx xo source/components/AddMealPage.tsx source/components/MealOptionsManager.tsx source/components/AddMealPage.test.tsx` *(fails: TypeError: Cannot read properties of undefined (reading 'getAllComments'))*
- `npx ava source/components/AddMealPage.test.tsx` *(fails: Uncaught exception in source/components/AddMealPage.test.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_68b3daaa14448327bc55c87491dc46ef